### PR TITLE
add return method in allowErrorListenerToHandle

### DIFF
--- a/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
+++ b/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
@@ -390,7 +390,7 @@ public class FensterVideoView extends TextureView implements MediaController.Med
 
     private boolean allowErrorListenerToHandle(final int frameworkError, final int implError) {
         if (mOnErrorListener != null) {
-            mOnErrorListener.onError(mMediaPlayer, frameworkError, implError);
+            return mOnErrorListener.onError(mMediaPlayer, frameworkError, implError);
         }
 
         return false;


### PR DESCRIPTION
I believe return statement is missing. otherwise custom error listener is never able to overwrite handleError message and popup "impossible to play video" is shown. 