### PR TITLE
Load from assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,54 @@ public void onBrightnessFinishedDragging() {
     mDragging = false;
 }
 ```
+
+Support for different video origins
+=============================
+
+The `setVideo()` method allows you to load remote or local video files. You can also set the start time of the video 
+(useful if you want to resume content), passing in a integer which corresponds to Milliseconds.
+
+### Loading a remote stream
+
+
+```java
+@Override
+protected void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+
+    textureView = (TextureVideoView) findViewById(R.id.play_video_texture);
+    playerController = (PlayerController) findViewById(R.id.play_video_controller);
+
+    textureView.setMediaController(playerController);
+
+    textureView.setVideo("http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4");
+    textureView.start();
+}
+```
+
+### Loading a local stream
+
+`Fenster` uses the [AssetFileDescriptor](http://developer.android.com/intl/es/reference/android/content/res/AssetFileDescriptor.html) in 
+order to load a local video stream.
+
+
+```java
+@Override
+protected void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+
+    textureView = (TextureVideoView) findViewById(R.id.play_video_texture);
+    playerController = (PlayerController) findViewById(R.id.play_video_controller);
+
+    textureView.setMediaController(playerController);
+    
+    AssetFileDescriptor assetFileDescriptor = getResources().openRawResourceFd(R.raw.big_buck_bunny);
+    textureView.setVideo(assetFileDescriptor);
+   
+    textureView.start();
+}
+```
+
   
 License
 -------

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,8 @@ repositories {
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile 'com.malmstein:fenster:0.0.1'
+    compile project(":library")
+//    compile 'com.malmstein:fenster:0.0.1'
 }
 
 android {

--- a/app/src/main/java/com/malmstein/fenster/demo/MediaPlayerDemoActivity.java
+++ b/app/src/main/java/com/malmstein/fenster/demo/MediaPlayerDemoActivity.java
@@ -20,6 +20,7 @@ public class MediaPlayerDemoActivity extends Activity implements View.OnClickLis
     private void bindViews() {
         findViewById(R.id.start_gesture_media_player_button).setOnClickListener(this);
         findViewById(R.id.start_simple_media_player_button).setOnClickListener(this);
+        findViewById(R.id.local_file_media_player_button).setOnClickListener(this);
     }
 
     @Override
@@ -30,6 +31,11 @@ public class MediaPlayerDemoActivity extends Activity implements View.OnClickLis
                 break;
             case R.id.start_simple_media_player_button:
                 startActivity(new Intent(this, SimpleMediaPlayerActivity.class));
+                break;
+            case R.id.local_file_media_player_button:
+                Intent localStream = new Intent(this, SimpleMediaPlayerActivity.class);
+                localStream.putExtra(SimpleMediaPlayerActivity.KEY_LOCAL_FILE, true);
+                startActivity(localStream);
                 break;
             default:
                 new Throwable("Bro I don't exist");

--- a/app/src/main/java/com/malmstein/fenster/demo/SimpleMediaPlayerActivity.java
+++ b/app/src/main/java/com/malmstein/fenster/demo/SimpleMediaPlayerActivity.java
@@ -1,6 +1,7 @@
 package com.malmstein.fenster.demo;
 
 import android.app.Activity;
+import android.content.res.AssetFileDescriptor;
 import android.os.Bundle;
 import android.view.View;
 
@@ -10,6 +11,7 @@ import com.malmstein.fenster.view.FensterVideoView;
 
 public class SimpleMediaPlayerActivity extends Activity implements FensterPlayerControllerVisibilityListener {
 
+    public static final String KEY_LOCAL_FILE = BuildConfig.APPLICATION_ID + "KEY_LOCAL_FILE";
     private FensterVideoView textureView;
     private SimpleMediaFensterPlayerController fullScreenMediaPlayerController;
 
@@ -26,8 +28,16 @@ public class SimpleMediaPlayerActivity extends Activity implements FensterPlayer
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
-        textureView.setVideo("http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4",
-                SimpleMediaFensterPlayerController.DEFAULT_VIDEO_START);
+
+        boolean localFile = getIntent().getExtras().containsKey(KEY_LOCAL_FILE);
+
+        if (localFile) {
+            AssetFileDescriptor assetFileDescriptor = getResources().openRawResourceFd(R.raw.big_buck_bunny);
+            textureView.setVideo(assetFileDescriptor);
+        } else {
+            textureView.setVideo("http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4");
+        }
+
         textureView.start();
     }
 

--- a/app/src/main/res/layout/activity_demo.xml
+++ b/app/src/main/res/layout/activity_demo.xml
@@ -6,10 +6,10 @@
   android:padding="@dimen/activity_horizontal_margin">
 
   <TextView
-    android:id="@+id/demo_activity_label"
+    android:id="@+id/demo_activity_controller_description"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:text="@string/demo_activity_label"
+    android:text="@string/description_demo_activity_controller"
     android:gravity="center" />
 
   <Button
@@ -24,5 +24,20 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:text="@string/title_gesture_media_player"/>
+
+  <TextView
+    android:id="@+id/demo_activity_origin_description"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/activity_vertical_margin"
+    android:text="@string/description_demo_activity_origin"
+    android:gravity="center" />
+
+  <Button
+    android:id="@+id/local_file_media_player_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/activity_vertical_margin"
+    android:text="@string/title_local_media_player" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_simple_media_player.xml
+++ b/app/src/main/res/layout/activity_simple_media_player.xml
@@ -3,7 +3,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/default_bg"
-  tools:context=".DemoActivity">
+  tools:context=".SimpleMediaPlayerActivity">
 
   <com.malmstein.fenster.view.FensterVideoView
     android:id="@+id/play_video_texture"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,11 +2,13 @@
 <resources>
 
   <string name="app_name">Fenster</string>
-  <string name="demo_activity_label">This demo shows two different MediaPlayer controllers. The Simple Media Controller demo displays a video in a TextureView with a customised Media Player Controller. The second demo extends de first one, allowing to use gestures in order to control the Media Player. </string>
+  <string name="description_demo_activity_controller">This demo shows two different MediaPlayer controllers. The Simple Media Controller demo displays a video in a TextureView with a customised Media Player Controller. The second demo extends de first one, allowing to use gestures in order to control the Media Player. </string>
+  <string name="description_demo_activity_origin">Alternatively, you can also load a file from the Raw folder</string>
 
   <string name="action_about">About</string>
 
   <string name="title_simple_media_player">Simple Media Player Controller</string>
   <string name="title_gesture_media_player">Gesture Media Player Controller</string>
+  <string name="title_local_media_player">Load file from local Raw folder using an AssetFileDescriptor</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,3 @@ allprojects {
         jcenter()
     }
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.1'
-}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,12 +21,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 19
+        targetSdkVersion 23
         versionCode versionMajor * 100**3 + versionMinor * 100**2 + versionPatch * 100 + versionBuild
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
     }

--- a/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
+++ b/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
@@ -51,25 +51,6 @@ public class FensterVideoView extends TextureView implements MediaController.Med
     public static final String TAG = "TextureVideoView";
     public static final int VIDEO_BEGINNING = 0;
 
-    /**
-     * Notifies periodically about replay.
-     */
-    public interface ReplayListener {
-        /**
-         * Called periodically to notify that we are still playing.
-         * <p/>
-         * Used to check whether we are still permitted to watch.
-         */
-        void onStillPlaying();
-    }
-
-    private static final ReplayListener NULL_REPLAY_LISTENER = new ReplayListener() {
-        @Override
-        public void onStillPlaying() {
-            // no op
-        }
-    };
-
     // all possible internal states
     private static final int STATE_ERROR = -1;
     private static final int STATE_IDLE = 0;
@@ -79,7 +60,6 @@ public class FensterVideoView extends TextureView implements MediaController.Med
     private static final int STATE_PAUSED = 4;
     private static final int STATE_PLAYBACK_COMPLETED = 5;
     private static final int MILLIS_IN_SEC = 1000;
-    private static final long NOTIFY_REPLAY_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(10);
 
     // collaborators / delegates / composites .. discuss
     private final VideoSizeCalculator videoSizeCalculator;

--- a/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
+++ b/library/src/main/java/com/malmstein/fenster/view/FensterVideoView.java
@@ -251,7 +251,7 @@ public class FensterVideoView extends TextureView implements MediaController.Med
     }
 
     private boolean notReadyForPlaybackJustYetWillTryAgainLater() {
-        return mUri == null || mSurfaceTexture == null;
+        return mSurfaceTexture == null;
     }
 
     private void tellTheMusicPlaybackServiceToPause() {


### PR DESCRIPTION
This PR adds the ability to load video streams for assets. The public API does not change, one just needs to use an `AssetFileDescriptor` to pass in the reference to the video

```java
AssetFileDescriptor assetFileDescriptor = getResources().openRawResourceFd(R.raw.big_buck_bunny);
textureView.setVideo(assetFileDescriptor);  
```