### PR TITLE
Improvements

### DIFF
--- a/library/src/main/java/com/malmstein/fenster/controller/FensterPlayerController.java
+++ b/library/src/main/java/com/malmstein/fenster/controller/FensterPlayerController.java
@@ -16,4 +16,8 @@ public interface FensterPlayerController {
 
     void setVisibilityListener(FensterPlayerControllerVisibilityListener visibilityListener);
 
+    boolean isShowing();
+
+    boolean isFirstTimeLoading();
+
 }

--- a/library/src/main/java/com/malmstein/fenster/controller/MediaFensterPlayerController.java
+++ b/library/src/main/java/com/malmstein/fenster/controller/MediaFensterPlayerController.java
@@ -264,10 +264,12 @@ public final class MediaFensterPlayerController extends RelativeLayout implement
         bottomControlsArea.setVisibility(View.VISIBLE);
     }
 
+    @Override
     public boolean isShowing() {
         return mShowing;
     }
 
+    @Override
     public boolean isFirstTimeLoading() {
         return mFirstTimeLoading;
     }

--- a/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
+++ b/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
@@ -511,9 +511,4 @@ public final class SimpleMediaFensterPlayerController extends FrameLayout implem
             show();
         }
     }
-
-    public interface IThemer {
-        void onThemeSeekbar(SeekBar seekbar);
-    }
-
 }

--- a/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
+++ b/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
@@ -174,6 +174,7 @@ public final class SimpleMediaFensterPlayerController extends FrameLayout implem
 
     }
 
+    @Override
     public boolean isShowing() {
         return mShowing;
     }
@@ -182,6 +183,7 @@ public final class SimpleMediaFensterPlayerController extends FrameLayout implem
         return mLoading;
     }
 
+    @Override
     public boolean isFirstTimeLoading() {
         return mFirstTimeLoading;
     }

--- a/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
+++ b/library/src/main/java/com/malmstein/fenster/controller/SimpleMediaFensterPlayerController.java
@@ -1,6 +1,9 @@
 package com.malmstein.fenster.controller;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.util.AttributeSet;
@@ -201,6 +204,28 @@ public final class SimpleMediaFensterPlayerController extends FrameLayout implem
         if (visibilityListener != null) {
             visibilityListener.onControlsVisibilityChange(false);
         }
+    }
+
+    /**
+     * hides the next/prev buttons
+     */
+    public void disableNavigationButtons() {
+        mNextButton.setVisibility(View.GONE);
+        mPrevButton.setVisibility(View.GONE);
+    }
+
+    /**
+     *  set a custom color for the progress view
+     *  works for android >= 21 only
+     */
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public void setSeekbarColor(ColorStateList color) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+            return;
+
+        SeekBar seekbar = (SeekBar) mProgress;
+        seekbar.setThumbTintList(color);
+        seekbar.setProgressTintList(color);
     }
 
     private String stringForTime(final int timeMs) {
@@ -483,6 +508,10 @@ public final class SimpleMediaFensterPlayerController extends FrameLayout implem
             Log.d(TAG, "controller ui touch received!");
             show();
         }
+    }
+
+    public interface IThemer {
+        void onThemeSeekbar(SeekBar seekbar);
     }
 
 }

--- a/library/src/main/res/layout/fen__view_simple_media_controller.xml
+++ b/library/src/main/res/layout/fen__view_simple_media_controller.xml
@@ -23,22 +23,20 @@
       <TextView
         android:id="@+id/fen__media_controller_time_current"
         style="@style/MediaText"
-        android:layout_width="0dip"
-        android:layout_height="wrap_content"
-        android:layout_weight="1" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
 
       <SeekBar
         android:id="@+id/fen__media_controller_progress"
         android:layout_width="0dip"
         android:layout_height="@dimen/fen__media_controller_seekbar_height"
-        android:layout_weight="8" />
+        android:layout_weight="1" />
 
       <TextView
         android:id="@+id/fen__media_controller_time"
         style="@style/MediaText"
-        android:layout_width="0dip"
-        android:layout_height="wrap_content"
-        android:layout_weight="1" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
This "fixes" following: https://github.com/malmstein/fenster/issues/29 https://github.com/malmstein/fenster/issues/30

I did following:

**SimpleMediaFensterPlayerController**
* corrected layout for seekbar and time text views - old weight based layouts may have lead to line breaks on small screens if durations are long (>1 hour for example)
* add the ability to theme the seekbar to a custom color (android >= 21 only)
* added the ability to disable the next/prev buttons

**General**
* added some common functions of both controllers to the common interface, namely `boolean isShowing()` and `boolean isFirstTimeLoading()`